### PR TITLE
fix: resolve PDF export icons path after configurable-icons change

### DIFF
--- a/Services/PdfExportService.cs
+++ b/Services/PdfExportService.cs
@@ -104,7 +104,7 @@ namespace ShiftScheduler.Services
                     var shift = shiftWithTransport.Shift;
                     if (shift.IsPngIcon) 
                     {
-                        var iconPath = Path.Combine(AppContext.BaseDirectory, "wwwroot", "icons", shift.Icon);
+                        var iconPath = Path.Combine(Directory.GetCurrentDirectory(), "config", "icons", shift.Icon);
                         if (File.Exists(iconPath))
                         {
                             table.Cell().Height(24).Element(CellStyleMiddle).Image(iconPath).FitArea();


### PR DESCRIPTION
## Summary
- PDF export was broken after the configurable-icons feature moved icons from `wwwroot/icons/` to `config/icons/`
- `PdfExportService` still used `AppContext.BaseDirectory/wwwroot/icons/` to resolve icon files
- Updated the path to `Directory.GetCurrentDirectory()/config/icons/` to match the location used by the static file middleware in `Program.cs`

## Test plan
- [ ] Generate a PDF export with shifts that have PNG icons configured
- [ ] Verify icons appear in the PDF output
- [ ] Verify shifts without icons still render the shift name as text fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)